### PR TITLE
Migrate to quarkus and add locale setting

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,9 +4,9 @@ jobs:
   gradle:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: 'adopt'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,10 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'adopt'
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,24 +2,26 @@ name: Publish Release
 on:
   release:
     types: [ published ]
+env:
+  REGISTRY_IMAGE: caseyscarborough/qbittorrent-exporter
 jobs:
   release:
     name: Docker Hub Release
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/checkout@v4
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
         with:
-          java-version: 17
-          distribution: 'adopt'
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
-      - name: Run the Gradle package task
-        run: './gradlew installDist'
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+          images: ${{ env.REGISTRY_IMAGE }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
@@ -27,16 +29,56 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: caseyscarborough/qbittorrent-exporter
-      - name: Build and push Docker image
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - release
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            type=raw,value=latest,enable=true
+            type=semver,pattern={{version}},value=${{ needs.build.outputs.shortversion }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## Stage 1 : build with maven builder image with native capabilities
-FROM quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-17 AS build
+FROM quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21 AS build
 USER root
 RUN microdnf install findutils
 COPY --chown=quarkus:quarkus gradlew /code/gradlew

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,21 @@
-FROM openjdk:17
-# Run ./gradlew installDist before running Docker build
+## Stage 1 : build with maven builder image with native capabilities
+FROM quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-17 AS build
+USER root
+RUN microdnf install findutils
+COPY --chown=quarkus:quarkus gradlew /code/gradlew
+COPY --chown=quarkus:quarkus gradle /code/gradle
+COPY --chown=quarkus:quarkus build.gradle /code/
+COPY --chown=quarkus:quarkus settings.gradle /code/
+COPY --chown=quarkus:quarkus gradle.properties /code/
+USER quarkus
+WORKDIR /code
+COPY src /code/src
+RUN ./gradlew build -Dquarkus.package.type=native
 
-COPY build/install/qbittorrent-exporter /opt/qbittorrent-exporter
-ENTRYPOINT ["/opt/qbittorrent-exporter/bin/qbittorrent-exporter"]
-
-EXPOSE 17871
+## Stage 2 : create the docker final image
+FROM quay.io/quarkus/quarkus-micro-image:2.0
+WORKDIR /work/
+COPY --from=build /code/build/*-runner /work/application
+RUN chmod 775 /work
+EXPOSE 8080
+CMD ["./application", "-Xmx50m"]

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ plugins {
 group = 'qbittorent.exporter'
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -10,34 +10,38 @@ plugins {
     // Apply the java plugin to add support for Java
     id 'java'
 
-    // Apply the application plugin to add support for building a CLI application.
-    id 'application'
+    // Quarkus framework
+    id 'io.quarkus'
 }
 
 group = 'qbittorent.exporter'
-sourceCompatibility = '17'
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    implementation 'org.apache.logging.log4j:log4j-core:2.17.0'
-    implementation 'org.apache.logging.log4j:log4j-api:2.17.0'
-    implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.0'
+    implementation 'com.google.code.gson:gson:2.10.1'
+    implementation 'io.prometheus:simpleclient:0.16.0'
+    implementation 'io.micrometer:micrometer-registry-prometheus:1.11.5'
 
-    implementation 'io.undertow:undertow-core:2.2.16.Final'
-    implementation 'io.undertow:undertow-servlet:2.2.15.Final'
-    implementation 'com.google.code.gson:gson:2.9.0'
-    implementation 'io.prometheus:simpleclient:0.15.0'
-    implementation 'io.micrometer:micrometer-registry-prometheus:1.8.2'
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-resteasy-reactive'
+    implementation 'io.quarkus:quarkus-arc'
+    implementation 'io.quarkus:quarkus-config-yaml'
+    implementation 'org.jboss.logmanager:log4j2-jboss-logmanager'
 }
 
 test {
     useJUnitPlatform()
 }
 
-application {
-    // Define the main class for the application.
-    mainClassName = 'qbittorrent.exporter.Application'
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,6 @@
+#Gradle properties
+quarkusPluginId=io.quarkus
+quarkusPluginVersion=3.5.0
+quarkusPlatformGroupId=io.quarkus.platform
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformVersion=3.5.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=3.5.0
+quarkusPluginVersion=3.6.6
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=3.5.0
+quarkusPlatformVersion=3.6.6

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,5 +6,14 @@
  * Detailed information about configuring a multi-project build in Gradle can be found
  * in the user manual at https://docs.gradle.org/6.2/userguide/multi_project_builds.html
  */
-
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+        mavenLocal()
+    }
+    plugins {
+        id "${quarkusPluginId}" version "${quarkusPluginVersion}"
+    }
+}
 rootProject.name = 'qbittorrent-exporter'

--- a/src/main/java/qbittorrent/config/ReflectionConfig.java
+++ b/src/main/java/qbittorrent/config/ReflectionConfig.java
@@ -1,0 +1,19 @@
+package qbittorrent.config;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import qbittorrent.api.model.MainData;
+import qbittorrent.api.model.Preferences;
+import qbittorrent.api.model.ServerState;
+import qbittorrent.api.model.Torrent;
+
+/**
+ * Registration of classes used in GSON Object mapping
+ */
+@RegisterForReflection(targets = {
+    MainData.class,
+    Preferences.class,
+    ServerState.class,
+    Torrent.class
+})
+public class ReflectionConfig {
+}

--- a/src/main/java/qbittorrent/exporter/Application.java
+++ b/src/main/java/qbittorrent/exporter/Application.java
@@ -1,64 +1,19 @@
 package qbittorrent.exporter;
 
-import io.undertow.Undertow;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import qbittorrent.api.ApiClient;
+import io.vertx.core.http.HttpServerResponse;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
 import qbittorrent.exporter.handler.QbtHttpHandler;
 
-import static io.undertow.Handlers.path;
-
+@Path("")
 public class Application {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(Application.class);
+    @Inject
+    QbtHttpHandler qbtHttpHandler;
 
-    private static final String USERNAME_ENVIRONMENT = "QBITTORRENT_USERNAME";
-    private static final String USERNAME_DEFAULT = "admin";
-    private static final String PASSWORD_ENVIRONMENT = "QBITTORRENT_PASSWORD";
-    private static final String PASSWORD_DEFAULT = "adminadmin";
-    private static final String HOST_ENVIRONMENT = "QBITTORRENT_HOST";
-    private static final String HOST_DEFAULT = "localhost";
-    private static final String PORT_ENVIRONMENT = "QBITTORRENT_PORT";
-    private static final String PORT_DEFAULT = "8080";
-    private static final String PROTOCOL_ENVIRONMENT = "QBITTORRENT_PROTOCOL";
-    private static final String PROTOCOL_DEFAULT = "http";
-    private static final String BASE_URL_ENVIRONMENT = "QBITTORRENT_BASE_URL";
-    private static final String METRICS_HOST = "0.0.0.0";
-    private static final String METRICS_PATH = "/metrics";
-    private static final int METRICS_PORT = 17871;
-
-    public static void main(String[] args) {
-        final String username = getEnvironment(USERNAME_ENVIRONMENT, USERNAME_DEFAULT);
-        final String password = getEnvironment(PASSWORD_ENVIRONMENT, PASSWORD_DEFAULT);
-        final String host = getEnvironment(HOST_ENVIRONMENT, HOST_DEFAULT);
-        final String port = getEnvironment(PORT_ENVIRONMENT, PORT_DEFAULT);
-        final String protocol = getEnvironment(PROTOCOL_ENVIRONMENT, PROTOCOL_DEFAULT);
-        final String baseUrl = getEnvironment(BASE_URL_ENVIRONMENT, String.format("%s://%s:%s", protocol, host, port));
-
-        final ApiClient client = new ApiClient(baseUrl, username, password);
-        try {
-            final QbtHttpHandler handler = new QbtHttpHandler(client);
-            final Undertow server = Undertow.builder()
-                .setIoThreads(2)
-                .setWorkerThreads(10)
-                .addHttpListener(METRICS_PORT, METRICS_HOST)
-                .setHandler(path().addPrefixPath(METRICS_PATH, handler))
-                .build();
-            server.start();
-            String url = String.format("http://%s:%s%s", METRICS_HOST, METRICS_PORT, METRICS_PATH);
-            LOGGER.info("Server is listening for connections at {}", url);
-        } catch (Exception e) {
-            LOGGER.error("Unable to start HTTP server", e);
-        }
-    }
-
-    private static String getEnvironment(final String key, final String fallback) {
-        final String value = System.getenv(key);
-        if (value != null && !value.isBlank()) {
-            LOGGER.debug("Environment variable {} found with value '{}'.", key, value);
-            return value;
-        }
-        LOGGER.debug("Environment variable {} was not found. Using default value '{}'.", key, fallback);
-        return fallback;
+    @GET
+    public void metrics(HttpServerResponse serverResponse) {
+        qbtHttpHandler.handleRequest(serverResponse);
     }
 }

--- a/src/main/java/qbittorrent/exporter/bean/QbtHttpHandlerBean.java
+++ b/src/main/java/qbittorrent/exporter/bean/QbtHttpHandlerBean.java
@@ -1,0 +1,57 @@
+package qbittorrent.exporter.bean;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import qbittorrent.api.ApiClient;
+import qbittorrent.exporter.handler.QbtHttpHandler;
+
+/**
+ * Bean definition for {@link QbtHttpHandler}.
+ *
+ * @author <a href="mailto:vincevillamora@gmail.com">Vince Villamora</a>
+ */
+@ApplicationScoped
+public class QbtHttpHandlerBean {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(QbtHttpHandlerBean.class);
+
+    @ConfigProperty(name = "qbittorrent.exporter.username")
+    private String username;
+
+    @ConfigProperty(name = "qbittorrent.exporter.password")
+    private String password;
+
+    @ConfigProperty(name = "qbittorrent.exporter.host")
+    private String host;
+
+    @ConfigProperty(name = "qbittorrent.exporter.port")
+    private String port;
+
+    @ConfigProperty(name = "qbittorrent.exporter.protocol")
+    private String protocol;
+
+    @ConfigProperty(name = "qbittorrent.exporter.baseUrl")
+    private String baseUrl;
+
+    @ConfigProperty(name = "qbittorrent.exporter.locale")
+    private String locale;
+
+    /**
+     * Creates a {@link QbtHttpHandler} instance using the default configurations
+     *
+     * @return {@link QbtHttpHandler} instance
+     */
+    @Produces
+    QbtHttpHandler qbtHttpHandler() {
+        final ApiClient client = new ApiClient(baseUrl, username, password);
+        try {
+            return new QbtHttpHandler(client, locale);
+        } catch (Exception e) {
+            LOGGER.error("Unable to create HTTP handler", e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/qbittorrent/exporter/handler/HttpHandler.java
+++ b/src/main/java/qbittorrent/exporter/handler/HttpHandler.java
@@ -1,0 +1,11 @@
+package qbittorrent.exporter.handler;
+
+import io.vertx.core.http.HttpServerResponse;
+
+/**
+ * Interface for extending HTTP handlers
+ */
+public interface HttpHandler {
+
+    void handleRequest(HttpServerResponse serverResponse);
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,8 +6,9 @@ quarkus:
     path: ${METRICS_PATH:/metrics}
   native:
     additional-build-args:
-      -march=compatibility,\
-      -H:+UnlockExperimentalVMOptions,-H:+IncludeAllLocales,-H:-UnlockExperimentalVMOptions
+      -march=compatibility
+  locales:
+    ar,ca,cs,de,en,es,fr,it,ja,mt,nl,pl,pt,pt_BR,ru,sk,uk,zh_CN,zh_HK,zh_TW
 
 qbittorrent:
   exporter:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,7 +8,7 @@ quarkus:
     additional-build-args:
       -march=compatibility
   locales:
-    ar,ca,cs,de,en,es,fr,it,ja,mt,nl,pl,pt,pt_BR,ru,sk,uk,zh_CN,zh_HK,zh_TW
+    all
 
 qbittorrent:
   exporter:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,20 @@
+quarkus:
+  http:
+    host: ${METRICS_HOST:0.0.0.0}
+    port: ${METRICS_PORT:17871}
+  resteasy-reactive:
+    path: ${METRICS_PATH:/metrics}
+  native:
+    additional-build-args:
+      -march=compatibility,\
+      -H:+UnlockExperimentalVMOptions,-H:+IncludeAllLocales,-H:-UnlockExperimentalVMOptions
+
+qbittorrent:
+  exporter:
+    username: ${QBITTORRENT_USERNAME:admin}
+    password: ${QBITTORRENT_PASSWORD:adminadmin}
+    host: ${QBITTORRENT_HOST:localhost}
+    port: ${QBITTORRENT_PORT:8080}
+    protocol: ${QBITTORRENT_PROTOCOL:http}
+    baseUrl: ${QBITTORRENT_BASE_URL:${qbittorrent.exporter.protocol}://${qbittorrent.exporter.host}:${qbittorrent.exporter.port}}
+    locale: ${QBITTORRENT_LOCALE:en-US}


### PR DESCRIPTION
Fixes: https://github.com/caseyscarborough/qbittorrent-exporter/issues/19 & https://github.com/caseyscarborough/qbittorrent-exporter/issues/15

Locale setting is defined in Environment variable: `QBITTORRENT_LOCALE`, defaults to `en-US`, uses [IETF BCP 47 language tag](https://en.wikipedia.org/wiki/IETF_language_tag) (also see [RFC 4647 "Matching of Language Tags"](https://www.rfc-editor.org/rfc/rfc4647) and [RFC 5646 "Tags for Identifying Languages"](https://www.rfc-editor.org/rfc/rfc5646)).

To review:
- [ ] Implications in using quarkus and compiling to native code
- [ ] Documentation update for environment variable
