### PR TITLE
Silence `LongTypeAdapter` logs

### DIFF
--- a/src/main/java/qbittorrent/api/gson/LongTypeAdapter.java
+++ b/src/main/java/qbittorrent/api/gson/LongTypeAdapter.java
@@ -28,7 +28,7 @@ public class LongTypeAdapter extends TypeAdapter<Long> {
         try {
             return Long.valueOf(value);
         } catch (NumberFormatException e) {
-            LOGGER.warn("Could not read long {} which had an invalid long value. Defaulting value to 0.", value);
+            LOGGER.debug("Could not read long {} which had an invalid long value. Defaulting value to 0.", value);
             return 0L;
         }
     }


### PR DESCRIPTION
Silence `LongTypeAdapter` logs, it doesn't really provide anything useful and it spams the log every time it pulls from the QBT API, switched it to debug logging

caused by: 1ef229a7240f4e75fc99e2f0bb3518173411161d