### PR TITLE
docker: use multi-stage builds to run gradle

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,15 +9,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          java-version: 17
-          distribution: 'adopt'
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
-      - name: Run the Gradle package task
-        run: './gradlew installDist'
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
-FROM openjdk:17
-# Run ./gradlew installDist before running Docker build
+FROM openjdk:17 AS build
 
-COPY build/install/qbittorrent-exporter /opt/qbittorrent-exporter
+COPY . /src
+WORKDIR /src
+RUN ./gradlew installDist
+
+FROM openjdk:17
+COPY --from=build /src/build/install/qbittorrent-exporter /opt/qbittorrent-exporter
 ENTRYPOINT ["/opt/qbittorrent-exporter/bin/qbittorrent-exporter"]
 
 EXPOSE 17871

--- a/README.md
+++ b/README.md
@@ -57,6 +57,5 @@ scrape_configs:
 Build the app and the docker container using the following commands:
 
 ```bash
-./gradlew build
-docker build .
+docker build -t qbittorrent-exporter .
 ```


### PR DESCRIPTION
This PR adds the gradle build step to the Dockerfile. This way, contributors don't need to set up JDK to build the Docker image.

Because we use a separate build stage, the size of the image is the same as what's currently available on Docker Hub (479MB according to `docker image ls`)

I updated the GH Actions workflow to remove the JDK build step for these changes.